### PR TITLE
Make indicatorView visible in order to allow customization

### DIFF
--- a/Pod/Classes/BetterSegmentedControl.swift
+++ b/Pod/Classes/BetterSegmentedControl.swift
@@ -174,6 +174,12 @@ import UIKit
         }
     }
     
+    public var indicatorContentView: UIView {
+        get {
+            return self.indicatorView
+        }
+    }
+    
     // MARK: - Private properties
     private let titleLabelsView = UIView()
     private let selectedTitleLabelsView = UIView()


### PR DESCRIPTION
The idea is to allow some customization. For exemple, it is possible to add some decoration views to the indicatorView (see attached video).
[Segmented.zip](https://github.com/gmarm/BetterSegmentedControl/files/348093/Segmented.zip)

The full ViewController code of the video:

```
import BetterSegmentedControl
import SnapKit
import UIKit

class HomeViewController: UIViewController {
    @IBOutlet private weak var segmentedControl: BetterSegmentedControl?

    // MARK: -
    // MARK: UIViewController
    override func viewDidLoad() {
         super.viewDidLoad()

        if let segmentedControl = self.segmentedControl {
            segmentedControl.titles = ["DEVIS", "RENDEZ-VOUS", "BILAN"]
            segmentedControl.titleFont = UIFont(named: .SegmentedTitle)!
            segmentedControl.selectedTitleFont = UIFont(named: .SegmentedSelectedTitle)!

            let separator = UIView()
            separator.backgroundColor = UIColor(named: .SegmentSelection)
            segmentedControl.indicatorContentView.addSubview(separator)
            separator.snp_makeConstraints { make in
                make.height.equalTo(2)
                make.width.equalTo(segmentedControl.indicatorContentView)
                make.centerX.equalTo(segmentedControl.indicatorContentView)
                make.bottom.equalTo(segmentedControl.indicatorContentView)
            }
        }
    }
}
```

Thanks for this component, IBDesignable components are too scarce.
