### PR TITLE
Add support for custom subviews in the indicator view

### DIFF
--- a/Example/BetterSegmentedControl/ViewController.swift
+++ b/Example/BetterSegmentedControl/ViewController.swift
@@ -75,6 +75,26 @@ class ViewController: UIViewController {
         viewSegmentedControl.bouncesOnChange = false
         viewSegmentedControl.panningDisabled = true
         view.addSubview(viewSegmentedControl)
+
+        // Control 5: Adding custom subview to Indicator
+        let indicatorControl = BetterSegmentedControl(
+            frame: CGRect(x: 0.0, y: 360.0, width: view.bounds.width, height: 50.0),
+            titles: ["Hello", "Goodbye"],
+            index: 0,
+            backgroundColor: .lightGray,
+            titleColor: .white,
+            indicatorViewBackgroundColor: .white,
+            selectedTitleColor: .black)
+        indicatorControl.autoresizingMask = [.flexibleWidth]
+        indicatorControl.bouncesOnChange = false
+        indicatorControl.panningDisabled = false
+
+        let customSubview = UIView(frame: CGRect(x: 0, y: 40, width: 40, height: 4.0))
+        customSubview.backgroundColor = .blue
+        customSubview.layer.cornerRadius = 2.0
+        customSubview.autoresizingMask = [.flexibleLeftMargin, .flexibleRightMargin]
+        indicatorControl.addSubviewToIndicator(customSubview)
+        view.addSubview(indicatorControl)
     }
     
     // MARK: - Action handlers

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -151,6 +151,18 @@ class BetterSegmentedControlSpec: QuickSpec {
                             expect(control.titleBorderColor).to(equal(UIColor.red.cgColor))
                         })
                     })
+                    describe("using addSubviewToIndicator") {
+                        var underlineView: UIView!
+                        beforeEach({
+                            underlineView = UIView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+                            control.addSubviewToIndicator(underlineView)
+                        })
+                        it("successfully adds the subview", closure: {
+                            expect(underlineView.superview).toNot(beNil())
+                            // TODO: @testable import doesn't seem to correctly import private members of a pod
+                            // expect(underlineView.superview).to(be(control.indicatorView))
+                        })
+                    }
                 }
                 context("using initWithCoder") {
                     var control: BetterSegmentedControl!

--- a/Pod/Classes/BetterSegmentedControl.swift
+++ b/Pod/Classes/BetterSegmentedControl.swift
@@ -289,7 +289,7 @@ import UIKit
     }
     
     // MARK: Index Setting
-    /*!
+    /**
      Sets the control's index.
      
      - parameter index:    The new index
@@ -304,6 +304,19 @@ import UIKit
         let oldIndex = self.index
         self.index = index
         moveIndicatorViewToIndex(animated, shouldSendEvent: (self.index != oldIndex || alwaysAnnouncesValue))
+    }
+
+    // MARK: Indicator View Customization
+
+    /**
+     Adds the given given view to the indicator view (the view which slides across segments to indicate the current selection)
+     
+     - parameter view: The view to add to the indicator
+     
+     - note: The added view must be able to layout & size itself and will not be autoresized.
+     */
+    public func addSubviewToIndicator(_ view: UIView) {
+        indicatorView.addSubview(view)
     }
     
     // MARK: Animations


### PR DESCRIPTION
Closes #46 

Below is a screenshot of what the demo page now looks like

![Custom subview example](https://cloud.githubusercontent.com/assets/2281949/24318506/cea6e2d6-10c3-11e7-8e5c-eab32a77f724.png)