### PR TITLE
Improve VoiceOver accessibility

### DIFF
--- a/BetterSegmentedControl.podspec
+++ b/BetterSegmentedControl.podspec
@@ -14,5 +14,6 @@ s.social_media_url = 'https://twitter.com/gmarmas'
 s.platform         = :ios, '9.0'
 s.requires_arc     = true
 s.source_files     = 'Pod/Classes/**/*'
+s.resource         = 'Pod/Assets/Localizations/*.lproj'
 s.frameworks       = 'UIKit'
 end

--- a/Pod/Assets/Localizations/cs.lproj/BetterSegmentedControlLocalizable.strings
+++ b/Pod/Assets/Localizations/cs.lproj/BetterSegmentedControlLocalizable.strings
@@ -1,0 +1,1 @@
+"Selected" = "Vybráno";

--- a/Pod/Assets/Localizations/en.lproj/BetterSegmentedControlLocalizable.strings
+++ b/Pod/Assets/Localizations/en.lproj/BetterSegmentedControlLocalizable.strings
@@ -1,0 +1,1 @@
+"Selected" = "Selected";

--- a/Pod/Assets/Localizations/sk.lproj/BetterSegmentedControlLocalizable.strings
+++ b/Pod/Assets/Localizations/sk.lproj/BetterSegmentedControlLocalizable.strings
@@ -1,0 +1,1 @@
+"Selected" = "Vybraté";

--- a/Pod/Classes/BetterSegmentedControl.swift
+++ b/Pod/Classes/BetterSegmentedControl.swift
@@ -46,12 +46,15 @@ import UIKit
                 return
             }
             
-            normalSegmentsView.subviews.forEach({ $0.removeFromSuperview() })
-            selectedSegmentsView.subviews.forEach({ $0.removeFromSuperview() })
+            normalSegmentsView.subviews.forEach { $0.removeFromSuperview() }
+            selectedSegmentsView.subviews.forEach { $0.removeFromSuperview() }
             
             for segment in segments {
                 normalSegmentsView.addSubview(segment.normalView)
                 selectedSegmentsView.addSubview(segment.selectedView)
+
+                segment.selectedView.isAccessibilityElement = false
+                segment.normalView.accessibilityTraits = .button
             }
             
             setNeedsLayout()
@@ -293,6 +296,7 @@ import UIKit
         let oldIndex = self.index
         self.index = index
         moveIndicatorViewToIndex(animated, shouldSendEvent: (self.index != oldIndex || alwaysAnnouncesValue))
+        updateAccessibilityLabels()
     }
     
     // MARK: Animations
@@ -343,6 +347,19 @@ import UIKit
     private func updateCornerRadii() {
         indicatorView.cornerRadius = cornerRadius - indicatorViewInset
         segmentViews.forEach { $0.layer.cornerRadius = indicatorView.cornerRadius }
+    }
+    private func updateAccessibilityLabels() {
+        let selectedText = NSLocalizedString("Selected",
+                                             tableName: "BetterSegmentedControlLocalizable",
+                                             bundle: Bundle(for: BetterSegmentedControl.self),
+                                             value: "",
+                                             comment: "")
+
+        for (segmentIndex, normalSegment) in normalSegments.enumerated() {
+            if let segmentText = segments[segmentIndex].text {
+                normalSegment.accessibilityLabel = segmentText + (segmentIndex == index ? " \(selectedText)" : "")
+            }
+        }
     }
     
     // MARK: Action handlers

--- a/Pod/Classes/BetterSegmentedControlSegment.swift
+++ b/Pod/Classes/BetterSegmentedControlSegment.swift
@@ -10,4 +10,5 @@ import UIKit
 public protocol BetterSegmentedControlSegment {
     var normalView: UIView { get }
     var selectedView: UIView { get }
+    var text: String? { get }
 }

--- a/Pod/Classes/Segments/IconSegment.swift
+++ b/Pod/Classes/Segments/IconSegment.swift
@@ -15,6 +15,7 @@ open class IconSegment: BetterSegmentedControlSegment {
     }
     
     // MARK: Properties
+    public let text: String? = nil
     public var icon: UIImage
     public var iconSize: CGSize
     


### PR DESCRIPTION
### The current state and problem

A blind person trying to use BetterSegmentedControl is unable to make sense of it. 

Let's say that we have a segmented control that looks like the following: 
`[First, Second, Third]` with Second being selected

VoiceOver would read that as `First First`, then upon moving to the next item, it would read `Second Second`, and then `Third Third`.

### Reason
This happens as there are two labels and VoiceOver reads them both.

### Solution

- keep only one label active for VoiceOver
- update the `accessibilityLabel` - add a `"Selected"` suffix for a selected item
- add localizations for the `"Selected"` text - currently added `en`, `cs` and `sk`
- add a button trait that signals to the user that he may click the item(s)


Now, with the example mentioned above, the  VoiceOver would read it as follows: 
`First (button)... Second selected (button)... Third (button)`,
which makes it usable for anyone using VoiceOver. 