### PR TITLE
Adding the ability to prevent event sending

### DIFF
--- a/Pod/Classes/BetterSegmentedControl.swift
+++ b/Pod/Classes/BetterSegmentedControl.swift
@@ -287,12 +287,13 @@ import UIKit
     /// - Parameters:
     ///   - index: The new index.
     ///   - animated: (Optional) Whether the change should be animated or not. Defaults to `true`.
-    public func setIndex(_ index: Int, animated: Bool = true) {
+    ///   - shouldSendEvent: (Optional) Whether the change should trigger an event. Default to `true`.
+    public func setIndex(_ index: Int, animated: Bool = true, shouldSendEvent: Bool = true) {
         guard normalSegments.indices.contains(index) else { return }
         
         let oldIndex = self.index
         self.index = index
-        moveIndicatorViewToIndex(animated, shouldSendEvent: (self.index != oldIndex || alwaysAnnouncesValue))
+        moveIndicatorViewToIndex(animated, shouldSendEvent: shouldSendEvent && (self.index != oldIndex || alwaysAnnouncesValue))
     }
     
     // MARK: Animations


### PR DESCRIPTION
This commit allows to prevent event sending when manually calling `setIndex()`. No breaking change expected.

An example use case is a declarative UI (React/SwiftUI like) calling this method when a render is triggered. Passing `false` to `shouldSendEvent` prevents an infinite loop (`setIndex` triggering an event -> triggering a render -> triggering call to `setIndex`).