### PR TITLE
Carthage fixes

### DIFF
--- a/Example/BetterSegmentedControl.xcodeproj/project.pbxproj
+++ b/Example/BetterSegmentedControl.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		607FACEC1AFB9204008FA782 /* BetterSegmentedControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 607FACEB1AFB9204008FA782 /* BetterSegmentedControlTests.swift */; };
 		90FFFDFEEFCF420B32DC095F /* Pods_BetterSegmentedControl_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2FAF265B133EF9D144E4D6FB /* Pods_BetterSegmentedControl_Tests.framework */; };
 		D36BA20F2BF5FBB03233C68B /* Pods_BetterSegmentedControl_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 61D9FAAAFFAE7994D65963C2 /* Pods_BetterSegmentedControl_Example.framework */; };
+		FB06F72426287F9C00158182 /* BetterSegmentedControl.h in Headers */ = {isa = PBXBuildFile; fileRef = FB06F72226287F9C00158182 /* BetterSegmentedControl.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +54,9 @@
 		E35EF8EE3A68B8AA955DE5DE /* Pods-BetterSegmentedControl_Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BetterSegmentedControl_Example.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BetterSegmentedControl_Example/Pods-BetterSegmentedControl_Example.debug.xcconfig"; sourceTree = "<group>"; };
 		F6F6B8A01C1E078308A9EB93 /* Pods-BetterSegmentedControl_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BetterSegmentedControl_Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-BetterSegmentedControl_Tests/Pods-BetterSegmentedControl_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		F8ECFF07790385FABB531EC7 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		FB06F72026287F9C00158182 /* BetterSegmentedControl.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BetterSegmentedControl.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FB06F72226287F9C00158182 /* BetterSegmentedControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BetterSegmentedControl.h; sourceTree = "<group>"; };
+		FB06F72326287F9C00158182 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -69,6 +73,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				90FFFDFEEFCF420B32DC095F /* Pods_BetterSegmentedControl_Tests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB06F71D26287F9C00158182 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -102,6 +113,7 @@
 				607FACF51AFB993E008FA782 /* Podspec Metadata */,
 				607FACD21AFB9204008FA782 /* Example for BetterSegmentedControl */,
 				607FACE81AFB9204008FA782 /* Tests */,
+				FB06F72126287F9C00158182 /* BetterSegmentedControl */,
 				607FACD11AFB9204008FA782 /* Products */,
 				2E0C0F03ED9410652539F30B /* Pods */,
 				D6EA7141AF371DB117A8E6FC /* Frameworks */,
@@ -113,6 +125,7 @@
 			children = (
 				607FACD01AFB9204008FA782 /* BetterSegmentedControl_Example.app */,
 				607FACE51AFB9204008FA782 /* BetterSegmentedControl_Tests.xctest */,
+				FB06F72026287F9C00158182 /* BetterSegmentedControl.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -176,7 +189,27 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		FB06F72126287F9C00158182 /* BetterSegmentedControl */ = {
+			isa = PBXGroup;
+			children = (
+				FB06F72226287F9C00158182 /* BetterSegmentedControl.h */,
+				FB06F72326287F9C00158182 /* Info.plist */,
+			);
+			path = BetterSegmentedControl;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		FB06F71B26287F9C00158182 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB06F72426287F9C00158182 /* BetterSegmentedControl.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		607FACCF1AFB9204008FA782 /* BetterSegmentedControl_Example */ = {
@@ -218,6 +251,24 @@
 			productReference = 607FACE51AFB9204008FA782 /* BetterSegmentedControl_Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		FB06F71F26287F9C00158182 /* BetterSegmentedControl */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FB06F72726287F9C00158182 /* Build configuration list for PBXNativeTarget "BetterSegmentedControl" */;
+			buildPhases = (
+				FB06F71B26287F9C00158182 /* Headers */,
+				FB06F71C26287F9C00158182 /* Sources */,
+				FB06F71D26287F9C00158182 /* Frameworks */,
+				FB06F71E26287F9C00158182 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BetterSegmentedControl;
+			productName = BetterSegmentedControl;
+			productReference = FB06F72026287F9C00158182 /* BetterSegmentedControl.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -237,6 +288,11 @@
 						LastSwiftMigration = 1020;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
+					FB06F71F26287F9C00158182 = {
+						CreatedOnToolsVersion = 12.4;
+						DevelopmentTeam = N34AH7UQAR;
+						ProvisioningStyle = Automatic;
+					};
 				};
 			};
 			buildConfigurationList = 607FACCB1AFB9204008FA782 /* Build configuration list for PBXProject "BetterSegmentedControl" */;
@@ -255,6 +311,7 @@
 			targets = (
 				607FACCF1AFB9204008FA782 /* BetterSegmentedControl_Example */,
 				607FACE41AFB9204008FA782 /* BetterSegmentedControl_Tests */,
+				FB06F71F26287F9C00158182 /* BetterSegmentedControl */,
 			);
 		};
 /* End PBXProject section */
@@ -275,6 +332,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				4BC57C101CCB8D0700A85349 /* Test.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB06F71E26287F9C00158182 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -380,6 +444,13 @@
 				4BC57C121CCB8EDD00A85349 /* TestViewControllers.swift in Sources */,
 				607FACEC1AFB9204008FA782 /* BetterSegmentedControlTests.swift in Sources */,
 				5E3D40EA253C486400FCF131 /* SnapshotHelpers.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		FB06F71C26287F9C00158182 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -582,6 +653,73 @@
 			};
 			name = Release;
 		};
+		FB06F72526287F9C00158182 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = N34AH7UQAR;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = BetterSegmentedControl/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.BetterSegmentedControl;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		FB06F72626287F9C00158182 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = N34AH7UQAR;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = BetterSegmentedControl/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cocoapods.BetterSegmentedControl;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -608,6 +746,15 @@
 			buildConfigurations = (
 				607FACF31AFB9204008FA782 /* Debug */,
 				607FACF41AFB9204008FA782 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		FB06F72726287F9C00158182 /* Build configuration list for PBXNativeTarget "BetterSegmentedControl" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FB06F72526287F9C00158182 /* Debug */,
+				FB06F72626287F9C00158182 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/BetterSegmentedControl.xcodeproj/xcshareddata/xcschemes/BetterSegmentedControl_Example.xcscheme
+++ b/Example/BetterSegmentedControl.xcodeproj/xcshareddata/xcschemes/BetterSegmentedControl_Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1240"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FB06F71F26287F9C00158182"
-               BuildableName = "BetterSegmentedControl.framework"
-               BlueprintName = "BetterSegmentedControl"
+               BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+               BuildableName = "BetterSegmentedControl_Example.app"
+               BlueprintName = "BetterSegmentedControl_Example"
                ReferencedContainer = "container:BetterSegmentedControl.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -28,6 +28,16 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "607FACE41AFB9204008FA782"
+               BuildableName = "BetterSegmentedControl_Tests.xctest"
+               BlueprintName = "BetterSegmentedControl_Tests"
+               ReferencedContainer = "container:BetterSegmentedControl.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction
@@ -40,6 +50,16 @@
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "BetterSegmentedControl_Example.app"
+            BlueprintName = "BetterSegmentedControl_Example"
+            ReferencedContainer = "container:BetterSegmentedControl.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"
@@ -47,15 +67,16 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "FB06F71F26287F9C00158182"
-            BuildableName = "BetterSegmentedControl.framework"
-            BlueprintName = "BetterSegmentedControl"
+            BlueprintIdentifier = "607FACCF1AFB9204008FA782"
+            BuildableName = "BetterSegmentedControl_Example.app"
+            BlueprintName = "BetterSegmentedControl_Example"
             ReferencedContainer = "container:BetterSegmentedControl.xcodeproj">
          </BuildableReference>
-      </MacroExpansion>
+      </BuildableProductRunnable>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/Example/BetterSegmentedControl/BetterSegmentedControl.h
+++ b/Example/BetterSegmentedControl/BetterSegmentedControl.h
@@ -1,0 +1,19 @@
+//
+//  BetterSegmentedControl.h
+//  BetterSegmentedControl
+//
+//  Created by Daedren on 15/04/2021.
+//  Copyright © 2021 CocoaPods. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for BetterSegmentedControl.
+FOUNDATION_EXPORT double BetterSegmentedControlVersionNumber;
+
+//! Project version string for BetterSegmentedControl.
+FOUNDATION_EXPORT const unsigned char BetterSegmentedControlVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <BetterSegmentedControl/PublicHeader.h>
+
+

--- a/Example/BetterSegmentedControl/Info.plist
+++ b/Example/BetterSegmentedControl/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -13,27 +13,10 @@
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundlePackageType</key>
-	<string>APPL</string>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
-	<key>LSRequiresIPhoneOS</key>
-	<true/>
-	<key>UILaunchStoryboardName</key>
-	<string>LaunchScreen</string>
-	<key>UIMainStoryboardFile</key>
-	<string>Main</string>
-	<key>UIRequiredDeviceCapabilities</key>
-	<array>
-		<string>armv7</string>
-	</array>
-	<key>UISupportedInterfaceOrientations</key>
-	<array>
-		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-	</array>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 </dict>
 </plist>


### PR DESCRIPTION
Carthage only looks at the .xcodeproj to look for the scheme to build, but said scheme in BetterSegmentedControl was looking at the target framework built in the Pods.xcodeproj.

So if you were using the .xcworkspace, you wouldn't notice anything, but if you opened the .xcodeproj in Xcode, you wouldn't be able to build the framework.

This adds a new target in the main xcodeproj that builds the framework, and the main schema now looks at that instead.

Closes #105 