### PR TITLE
Added AttributedLabelSegment to allow NSAttributedString segments.

### DIFF
--- a/Pod/Classes/Segments/AttributedLabelSegment.swift
+++ b/Pod/Classes/Segments/AttributedLabelSegment.swift
@@ -1,0 +1,117 @@
+//
+//  AttributedLabelSegment.swift
+//  BetterSegmentedControl
+//
+//  Created by Greg Gardner on 08/12/2021.
+//
+
+#if canImport(UIKit)
+
+import UIKit
+
+open class AttributedLabelSegment: BetterSegmentedControlSegment {
+    // MARK: Constants
+    private struct DefaultValues {
+        static let normalBackgroundColor: UIColor = .clear
+        static let normalTextColor: UIColor = .black
+        static let normalFont: UIFont = .systemFont(ofSize: 13)
+        static let selectedBackgroundColor: UIColor = .clear
+        static let selectedTextColor: UIColor = .black
+        static let selectedFont: UIFont = .systemFont(ofSize: 13, weight: .medium)
+    }
+    
+    // MARK: Properties
+    public let attributedText: NSAttributedString?
+    
+    public let normalFont: UIFont
+    public let normalTextColor: UIColor
+    public let normalBackgroundColor: UIColor
+    
+    public let selectedFont: UIFont
+    public let selectedTextColor: UIColor
+    public let selectedBackgroundColor: UIColor
+    
+    private let numberOfLines: Int
+    private let accessibilityIdentifier: String?
+    
+    // MARK: Lifecycle
+    public init(attributedText: NSAttributedString? = nil,
+                numberOfLines: Int = 1,
+                normalBackgroundColor: UIColor? = nil,
+                normalFont: UIFont? = nil,
+                normalTextColor: UIColor? = nil,
+                selectedBackgroundColor: UIColor? = nil,
+                selectedFont: UIFont? = nil,
+                selectedTextColor: UIColor? = nil,
+                accessibilityIdentifier: String? = nil) {
+        self.attributedText = attributedText
+        self.numberOfLines = numberOfLines
+        self.normalBackgroundColor = normalBackgroundColor ?? DefaultValues.normalBackgroundColor
+        self.normalFont = normalFont ?? DefaultValues.normalFont
+        self.normalTextColor = normalTextColor ?? DefaultValues.normalTextColor
+        self.selectedBackgroundColor = selectedBackgroundColor ?? DefaultValues.selectedBackgroundColor
+        self.selectedFont = selectedFont ?? DefaultValues.selectedFont
+        self.selectedTextColor = selectedTextColor ?? DefaultValues.selectedTextColor
+        self.accessibilityIdentifier = accessibilityIdentifier
+    }
+    
+    // MARK: BetterSegmentedControlSegment
+    public var intrinsicContentSize: CGSize? {
+        selectedView.intrinsicContentSize
+    }
+    
+    public lazy var normalView: UIView = {
+        createLabel(withAttributedText: attributedText,
+                    backgroundColor: normalBackgroundColor,
+                    font: normalFont,
+                    textColor: normalTextColor,
+                    accessibilityIdentifier: accessibilityIdentifier)
+    }()
+    public lazy var selectedView: UIView = {
+        createLabel(withAttributedText: attributedText,
+                    backgroundColor: selectedBackgroundColor,
+                    font: selectedFont,
+                    textColor: selectedTextColor,
+                    accessibilityIdentifier: accessibilityIdentifier)
+    }()
+    open func createLabel(withAttributedText attributedText: NSAttributedString?,
+                          backgroundColor: UIColor,
+                          font: UIFont,
+                          textColor: UIColor,
+                          accessibilityIdentifier: String?) -> UILabel {
+        let label = UILabel()
+        label.attributedText = attributedText
+        label.numberOfLines = numberOfLines
+        label.backgroundColor = backgroundColor
+        label.font = font
+        label.textColor = textColor
+        label.lineBreakMode = .byTruncatingTail
+        label.textAlignment = .center
+        label.accessibilityIdentifier = accessibilityIdentifier
+        return label
+    }
+}
+
+public extension AttributedLabelSegment {
+    class func segments(withTitles titles: [NSAttributedString],
+                        numberOfLines: Int = 1,
+                        normalBackgroundColor: UIColor? = nil,
+                        normalFont: UIFont? = nil,
+                        normalTextColor: UIColor? = nil,
+                        selectedBackgroundColor: UIColor? = nil,
+                        selectedFont: UIFont? = nil,
+                        selectedTextColor: UIColor? = nil) -> [BetterSegmentedControlSegment] {
+        titles.map {
+            AttributedLabelSegment(attributedText: $0,
+                         numberOfLines: numberOfLines,
+                         normalBackgroundColor: normalBackgroundColor,
+                         normalFont: normalFont,
+                         normalTextColor: normalTextColor,
+                         selectedBackgroundColor: selectedBackgroundColor,
+                         selectedFont: selectedFont,
+                         selectedTextColor: selectedTextColor)
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
For my needs I decided to add a new AttributedLabelSegment which can be used to set the attributedText on the label. This allows you to use much more than just strings or icons in each segment.

For instance, using NSTextAttachment you can create segments that have both an image and a string. Or you can have underline, strikeout text, etc. as well.

Would be great to have this merged in so that I don't have to use my fork long term, but that is up to you if you think this is generally useful.